### PR TITLE
Nginx: Parse all PHP files using Octane to avoid reavealing php sourcecode 

### DIFF
--- a/octane.md
+++ b/octane.md
@@ -283,12 +283,12 @@ server {
 
     charset utf-8;
 
-    location /index.php {
-        try_files /not_exists @octane;
-    }
-
     location / {
         try_files $uri $uri/ @octane;
+    }
+
+    location ~ \.php$ {
+        include octane.conf;
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }


### PR DESCRIPTION
I had no chance to chek this on my side yet, but @fideloper suggested to update the Nginx config proposal according to the discussion and suggestion in the this octane issue: https://github.com/laravel/octane/issues/900#issuecomment-2140520600

With the current documented config, PHP files in public folder other than index.js will just be downloaded as sourcecode. Instead of this, they should be parsed via Octane.